### PR TITLE
added support for setting null fields

### DIFF
--- a/reflectx/reflectx.go
+++ b/reflectx/reflectx.go
@@ -192,6 +192,10 @@ func FieldByIndexes(v reflect.Value, indexes []int) reflect.Value {
 		v = reflect.Indirect(v).Field(i)
 		// if this is a pointer, it's possible it is nil
 		if v.Kind() == reflect.Ptr && v.IsNil() {
+			if !v.CanSet() {
+				continue
+			}
+
 			alloc := reflect.New(Deref(v.Type()))
 			v.Set(alloc)
 		}

--- a/sqlx-runner/fixtures_test.go
+++ b/sqlx-runner/fixtures_test.go
@@ -18,6 +18,7 @@ type Person struct {
 	Key       dat.NullString  `db:"key"`
 	Name      string          `db:"name"`
 	CreatedAt dat.NullTime    `db:"created_at"`
+	Nullable  *string         `db:"nullable"`
 
 	Posts []*Post `json:"posts"`
 }
@@ -79,7 +80,8 @@ const createTables = `
 		image bytea,
 		key text,
 		name text NOT NULL,
-		created_at timestamptz default now()
+		created_at timestamptz default now(),
+		nullable text
 	);
 	CREATE TABLE posts (
 		id SERIAL PRIMARY KEY,

--- a/sqlx-runner/insert_exec_test.go
+++ b/sqlx-runner/insert_exec_test.go
@@ -124,6 +124,17 @@ func TestInsertReal(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, person2.ID > 0)
 	assert.NotEqual(t, person.ID, person2.ID)
+
+	person3 := Person{Name: "Barack", Nullable: nil}
+	err = s.
+		InsertInto("people").
+		Columns("name", "nullable").
+		Record(person3).
+		Returning("id", "nullable").
+		QueryStruct(&person3)
+	assert.True(t, person3.ID > 0)
+	assert.NotEqual(t, person2.ID, person3.ID)
+	assert.Nil(t, person3.Nullable)
 }
 
 func TestInsertMultipleRecords(t *testing.T) {

--- a/sqlx-runner/select_exec_test.go
+++ b/sqlx-runner/select_exec_test.go
@@ -86,7 +86,7 @@ func TestSelectQueryStruct(t *testing.T) {
 	// Found:
 	var person Person
 	err := s.
-		Select("id", "name", "email").
+		Select("id", "name", "email", "nullable").
 		From("people").
 		Where("email = $1", "john@acme.com").
 		QueryStruct(&person)
@@ -95,11 +95,12 @@ func TestSelectQueryStruct(t *testing.T) {
 	assert.Equal(t, person.Name, "John")
 	assert.True(t, person.Email.Valid)
 	assert.Equal(t, person.Email.String, "john@acme.com")
+	assert.Nil(t, person.Nullable)
 
 	// Not found:
 	var person2 Person
 	err = s.
-		Select("id", "name", "email").
+		Select("id", "name", "email", "nullable").
 		From("people").Where("email = $1", "dontexist@acme.com").
 		QueryStruct(&person2)
 	assert.Contains(t, err.Error(), "no rows")


### PR DESCRIPTION
# Issue
Added support for setting a nullable field. Previously this would fail because a nil pointer cannot be set:

```golang
# Nullable  *string         `db:"nullable"`

person3 := Person{Name: "Barack", Nullable: nil}
err = s.
	InsertInto("people").
	Columns("name", "nullable").
	Record(person3).
	Returning("id", "nullable").
	QueryStruct(&person3)
```

# Fix
The fix (discovered by @pascallouisperez) is to skip fields that `!v.CanSet()`.

# Tests
I added tests for inserting selecting and updating nullable fields.

